### PR TITLE
Medibork changes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -197,11 +197,34 @@
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src) //In case the chemist is nice!
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker(src)//For holding the chemicals when the chemist is nice
 	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
+	src.modules += new /obj/item/weapon/gripper/medical(src)//Now you can set up cyro or make peri.
 	src.modules += new /obj/item/weapon/shockpaddles/robot/hound(src) //Paws of life
 	src.emag 	 = new /obj/item/weapon/dogborg/pounce(src) //Pounce
 	R.icon = 'icons/mob/widerobot_vr.dmi'
 	R.hands.icon = 'icons/mob/screen1_robot_vr.dmi'
 	R.ui_style_vr = TRUE
+	
+	//Adds tools for medihound to treat patients without sleeper. Traumakits, Advance Ointment, and Splints.
+	
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
+	synths += medicine
+
+	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
+	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
+	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
+	O.uses_charge = 1
+	O.charge_costs = list(1000)
+	O.synths = list(medicine)
+	B.uses_charge = 1
+	B.charge_costs = list(1000)
+	B.synths = list(medicine)
+	S.uses_charge = 1
+	S.charge_costs = list(1000)
+	S.synths = list(medicine)
+	src.modules += O
+	src.modules += B
+	src.modules += S
+	
 	//R.icon_state = "medihound"
 	R.pixel_x 	 = -16
 	R.old_x  	 = -16


### PR DESCRIPTION
This will change the load out for mediborks. 
It will add:

****Medical Gripper. Allows borgs to pick up beakers and open bottles. As well as pick up phoron crystals for grinding. This will allow them to create phoron based chems and setup cryo byond (heh) just turning them on. It also allows them to pick up pills and force them on patients such as carbon pills. It also allows picking up blood packs and placing them in IV's.
Full list of items are that can be picked up are:
 /obj/item/weapon/reagent_containers/glass,
		/obj/item/weapon/storage/pill_bottle,
		/obj/item/weapon/reagent_containers/pill,
		/obj/item/weapon/reagent_containers/blood,
                /obj/item/stack/material/phoron

****Traumakits, Advance Burn kits, and Splints.

Items work just as the normal ones. The only twist is that they got practically infinite ammo.  (1000 actually according to the code) 
However, Do not be fooled by the amount of charge it has when examining it.
But they may only apply it once per-limb so no heal spamming. Even after that limb takes damage again. You got to wait until the "already treated" thing wears off to reapply.

*Traumakits: The main use of the trauma kit is to stop external bleeding.
*Burn Pack: Main use of burnpack (ointment) Is to treat burn damage overtime. It seems useless next to the hypospray but who knows. It treats about 2.2 burn damage on use so it just might bring a burned victim's damage down enough to be defibbed.
*Splints: Lets you treat a patient with bone damage as best you can while waiting for a surgeon to show up. Of course won't actually fix anything, but at least they'll stop falling down in pain or dealing self damage by moving with broken bones.